### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "intx"
+description := "Extended precision integer C++ library."
+gitrepo     := "https://github.com/chfast/intx.git"
+homepage    := "https://github.com/chfast/intx/"
+version     := 0.4.0 sha256:b25f71b5c2575443444b2f2dffd60b8825dc06e6f0a144a38e0d58fffa91420a https://github.com/chfast/intx/archive/v0.4.0.tar.gz
+license     := "Apache-2.0"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

