### PR TITLE
lib-intx: Update library to 0.10.0

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -40,7 +40,7 @@ $(eval $(call addlib_s,libintx,$(CONFIG_LIBINTX)))
 ################################################################################
 # Sources
 ################################################################################
-LIBINTX_VERSION=0.4.0
+LIBINTX_VERSION=0.10.0
 LIBINTX_URL=https://github.com/chfast/intx/archive/v$(LIBINTX_VERSION).tar.gz
 LIBINTX_PATCHDIR=$(LIBINTX_BASE)/patches
 $(eval $(call fetch,libintx,$(LIBINTX_URL)))


### PR DESCRIPTION
Issue https://github.com/unikraft/lib-intx/issues/3
At line 43, in Makefile.uk update version from `LIBINTX_VERSION=0.4.0` to `LIBINTX_VERSION=0.10.0`